### PR TITLE
chore: use dig for dns resolution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --no-cache \
        rsyslog \
        sed \
        socat \
+       bind-tools \
     ;
 
 ENV RSYSLOG=y

--- a/render_cfg.sh
+++ b/render_cfg.sh
@@ -27,7 +27,7 @@ else
 
   # Resolve DNS
   for _service in ${service//,/ }; do
-    nslookup $_service 2>/dev/null | gawk '/Address /{print $3}'
+    dig $_service 2>/dev/null | gawk '/'$_service'. /{ if (length ($5) > 1) print $5}'
   done | sort | paste -sd ',' > $tmpfile
   if [ $(wc -c $tmpfile | gawk '{print $1}') -eq 0 ]; then
     rm $tmpfile


### PR DESCRIPTION
Using `dig`

<img width="911" alt="Screenshot 2020-11-17 at 11 11 18" src="https://user-images.githubusercontent.com/1674464/99376787-b0835f00-28c5-11eb-89d8-a22af4947f2e.png">

Using old version of `nslookup` (screenshot from LB running in Rancher)

<img width="847" alt="Screenshot 2020-11-17 at 11 12 47" src="https://user-images.githubusercontent.com/1674464/99376900-d90b5900-28c5-11eb-9433-c67916d7534f.png">

Uploading screenshots ☝️ to confirm that the format is not broken after the change.